### PR TITLE
feat: サインアップページ（団体）

### DIFF
--- a/frontend/src/app/group/signup/page.tsx
+++ b/frontend/src/app/group/signup/page.tsx
@@ -1,0 +1,5 @@
+import { SignUpPage } from "@/features/auth/SignUpPage/group";
+
+const SignUp = () => <SignUpPage />;
+
+export default SignUp;

--- a/frontend/src/components/ui-parts/CheckBox/index.tsx
+++ b/frontend/src/components/ui-parts/CheckBox/index.tsx
@@ -9,6 +9,7 @@ type Props = {
   initialState?: boolean;
   onChange?: (_: boolean) => void;
   className?: string;
+  children?: React.ReactNode;
 };
 
 const noop = (_: boolean) => {};
@@ -18,6 +19,7 @@ export const CheckBox = ({
   initialState = false,
   onChange = noop,
   className,
+  children,
   ...props
 }: Props) => {
   const [state, toggle] = useReducer((state) => {
@@ -31,6 +33,7 @@ export const CheckBox = ({
     <label className={joinClassnames(styles.base, className)}>
       <input type="checkbox" checked={state} onChange={toggle} {...props} />
       {label}
+      {children}
     </label>
   );
 };

--- a/frontend/src/features/auth/SignUpPage/group/Confirmation/index.tsx
+++ b/frontend/src/features/auth/SignUpPage/group/Confirmation/index.tsx
@@ -1,0 +1,72 @@
+import { useRouter } from "next/navigation";
+import { useRef } from "react";
+
+import { TermsOfUseAndPrivacyPolicyModal } from "../../TermsOfUseAndPrivacyPolicyModal";
+
+import type { CreateGroupAccountRequestBody } from "@/__generated__/command";
+import type { FormValues } from "../useInputForm";
+
+import { apiClientGroup } from "@/api/command";
+import { CheckBox } from "@/components/ui-parts/CheckBox";
+import { URL_PATH_GROUP } from "@/consts";
+import { getUid } from "@/features/auth/utils/getUid";
+
+type Props = {
+  values: FormValues;
+  onPrevPage: () => void;
+};
+
+export const Confirmation = ({ values, onPrevPage }: Props) => {
+  const router = useRouter();
+
+  const isAgreed = useRef(false);
+
+  const handleAgreed = (value: boolean) => {
+    isAgreed.current = value;
+  };
+
+  const handleSubmit = async () => {
+    if (!isAgreed.current) {
+      alert("利用規約とプライバシーポリシーに同意してください");
+      return;
+    }
+    const uid = await getUid();
+    if (!uid) {
+      throw new Error("uid is null");
+    }
+    const body: CreateGroupAccountRequestBody = {
+      ...values,
+      gid: uid,
+    };
+
+    try {
+      await apiClientGroup.createGroupAccount(body);
+      router.push(URL_PATH_GROUP.HOME);
+    } catch (e) {
+      console.error(e);
+      alert("アカウント作成に失敗しました");
+    }
+  };
+
+  return (
+    <div>
+      <h1>入力情報確認</h1>
+      <button onClick={onPrevPage}>戻る</button>
+      <div>
+        <span>{values.furigana}</span>
+        <h1>{values.name}</h1>
+        <p>{values.address}</p>
+        <p>{values.phone}</p>
+      </div>
+      <div>
+        <p>{values.contents}</p>
+      </div>
+      <label>
+        <CheckBox label="" onChange={handleAgreed}>
+          <TermsOfUseAndPrivacyPolicyModal />
+        </CheckBox>
+      </label>
+      <button onClick={handleSubmit}>会員登録する</button>
+    </div>
+  );
+};

--- a/frontend/src/features/auth/SignUpPage/group/index.tsx
+++ b/frontend/src/features/auth/SignUpPage/group/index.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+import { Confirmation } from "./Confirmation";
+import { useInputForm } from "./useInputForm";
+
+export const SignUpPage = () => {
+  const [page, setPage] = useState<"input" | "confirm">("input");
+  const toConfirm = () => setPage("confirm");
+  const toInput = () => setPage("input");
+
+  const { formValues, InputForm } = useInputForm({ onSubmit: toConfirm });
+
+  return (
+    <div>
+      <div>
+        {/* TODO:アイコンを差し替える */}
+        <Image src={"/icon.svg"} alt="user icon" width={100} height={100} />
+      </div>
+      {page === "input" && InputForm}
+      {page === "confirm" && (
+        <Confirmation values={formValues} onPrevPage={toInput} />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/features/auth/SignUpPage/group/useInputForm/index.tsx
+++ b/frontend/src/features/auth/SignUpPage/group/useInputForm/index.tsx
@@ -1,0 +1,69 @@
+import { useForm } from "react-hook-form";
+
+export type FormValues = {
+  name: string;
+  furigana: string;
+  address: string;
+  phone: string;
+  contents: string;
+};
+
+type Props = {
+  onSubmit?: (data: FormValues) => void;
+};
+
+const noop = () => {};
+
+export const useInputForm = ({ onSubmit = noop }: Props) => {
+  const { register, handleSubmit, getValues } = useForm<FormValues>({
+    defaultValues: {
+      name: "",
+      furigana: "",
+      address: "",
+      phone: "",
+      contents: "",
+    },
+  });
+
+  const formValues = getValues();
+
+  const InputForm: JSX.Element = (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <h1>新規会員登録</h1>
+      <label>
+        <span>団体名</span>
+        <input
+          type="text"
+          {...register("name")}
+          placeholder="NPO法人 VolunScout"
+        />
+      </label>
+      <label>
+        <span>フリガナ</span>
+        <input
+          type="text"
+          {...register("furigana")}
+          placeholder="エヌピーオーホウジン ボランスカウト"
+        />
+      </label>
+      <label>
+        <span>所在地</span>
+        <input
+          type="text"
+          {...register("address")}
+          placeholder="東京都千代田区神田神保町 1-50"
+        />
+      </label>
+      <label>
+        <span>電話番号</span>
+        <input type="text" {...register("phone")} placeholder="0312345678" />
+      </label>
+      <label>
+        <span>紹介メッセージ（後から変更可能です）</span>
+        <textarea {...register("contents")}></textarea>
+      </label>
+      <button type="submit">入力情報の確認へ</button>
+    </form>
+  );
+  return { formValues, InputForm };
+};


### PR DESCRIPTION
## 対応する課題のチケット URL

- #20 

## :question: 目的・背景(Why)

- 団体のサインアップページの作成

## :up: 変更点(What)

- `frontend/src/components/ui-parts/CheckBox/index.tsx`
- `frontend/src/features/auth/SignUpPage/group/`
- `frontend/src/app/group/signup/page.tsx`

## :pick: やったこと(How)

- チェックボックスが `children` を受け取るように変更
- `frontend/src/features/auth/SignUpPage/group/` 配下にサインアップページの実体を作成
- 上記の実体を `frontend/src/app/group/signup/page.tsx` で呼び出し

## :red_circle: デプロイ・マイグレーション

- 特になし

## :camera_flash: （動作）確認内容・スクショ

![image](https://github.com/ishida-0622/VolunScout/assets/90295371/58fb571b-3870-4ef6-a1e9-db22853df82d)
![image](https://github.com/ishida-0622/VolunScout/assets/90295371/df58737e-d576-43cc-8a03-8dd2306546bc)
![image](https://github.com/ishida-0622/VolunScout/assets/90295371/d692c0ce-c1b3-4d5f-ba72-e3cdeee516d5)
![image](https://github.com/ishida-0622/VolunScout/assets/90295371/65264953-be07-4b58-9b33-d4a39a1ad0c6)

## :eyes: 重点的にレビューしてほしいところ・気になっているところ

- 特になし

close #20 