### PR TITLE
fix: 文字数カウントの方法を修正

### DIFF
--- a/backend/domain/src/model/user_account.rs
+++ b/backend/domain/src/model/user_account.rs
@@ -74,11 +74,3 @@ impl Review {
         self.value = Some(value);
     }
 }
-
-#[test]
-fn test_user_id() {
-    let uid = UserId::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
-    assert_eq!(uid.to_string(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-    let uid = UserId::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-    assert_eq!(uid.is_err(), true);
-}

--- a/backend/domain/src/model/user_account/user_id.rs
+++ b/backend/domain/src/model/user_account/user_id.rs
@@ -40,3 +40,32 @@ impl std::str::FromStr for UserId {
         Self::new(s)
     }
 }
+
+#[cfg(test)]
+mod test_user_id {
+    use super::*;
+
+    #[test]
+    fn ok() {
+        let uid = UserId::new("abcdefghijklmnopqrstuvwxyz12").unwrap();
+        assert_eq!(uid.to_string(), "abcdefghijklmnopqrstuvwxyz12");
+    }
+
+    #[test]
+    fn empty() {
+        let uid = UserId::new("");
+        assert_eq!(uid.is_err(), true);
+    }
+
+    #[test]
+    fn too_long() {
+        let uid = UserId::new("abcdefghijklmnopqrstuvwxyz123");
+        assert_eq!(uid.is_err(), true);
+    }
+
+    #[test]
+    fn too_short() {
+        let uid = UserId::new("abcdefghijklmnopqrstuvwxyz1");
+        assert_eq!(uid.is_err(), true);
+    }
+}

--- a/backend/domain/src/model/user_account/user_name.rs
+++ b/backend/domain/src/model/user_account/user_name.rs
@@ -17,7 +17,7 @@ impl UserName {
     pub fn new(name: &str) -> Result<UserName> {
         if name.is_empty() {
             Err(UserNameError::Empty.into())
-        } else if name.len() > 50 {
+        } else if name.chars().count() > 50 {
             Err(UserNameError::TooLong.into())
         } else {
             Ok(UserName(name.to_string()))

--- a/backend/domain/src/model/user_account/user_name.rs
+++ b/backend/domain/src/model/user_account/user_name.rs
@@ -41,8 +41,37 @@ impl std::str::FromStr for UserName {
     }
 }
 
-#[test]
-fn test_user_name() {
-    let name = UserName::new("石田健太郎").unwrap();
-    assert_eq!(name.to_string(), "石田健太郎");
+#[cfg(test)]
+mod test_user_name {
+    use super::*;
+
+    #[test]
+    fn ok() {
+        let name = UserName::new("石田健太郎").unwrap();
+        assert_eq!(name.to_string(), "石田健太郎");
+    }
+
+    #[test]
+    fn empty() {
+        let name = UserName::new("");
+        assert_eq!(name.is_err(), true);
+    }
+
+    #[test]
+    fn too_long() {
+        let name = UserName::new("寿限無寿限無五劫の擦り切れ海砂利水魚の水行末雲来末風来末食う寝る処に住む処やぶら小路の藪柑子パイポパイポパイポのシューリンガンシューリンガンのグーリンダイグーリンダイのポンポコピーのポンポコナーの長久命の長助");
+        assert_eq!(name.is_err(), true);
+    }
+
+    #[test]
+    fn length_50() {
+        let name = UserName::new("寿限無寿限無五劫の擦り切れ海砂利水魚の水行末雲来末風来末食う寝る処に住む処やぶら小路の藪柑子パイポパ");
+        assert_eq!(name.is_ok(), true);
+    }
+
+    #[test]
+    fn length_51() {
+        let name = UserName::new("寿限無寿限無五劫の擦り切れ海砂利水魚の水行末雲来末風来末食う寝る処に住む処やぶら小路の藪柑子パイポパイ");
+        assert_eq!(name.is_err(), true);
+    }
 }

--- a/backend/domain/src/model/user_account/user_name_furigana.rs
+++ b/backend/domain/src/model/user_account/user_name_furigana.rs
@@ -17,7 +17,7 @@ impl UserNameFurigana {
     pub fn new(furigana: &str) -> Result<UserNameFurigana> {
         if furigana.is_empty() {
             Err(UserNameFuriganaError::Empty.into())
-        } else if furigana.len() > 50 {
+        } else if furigana.chars().count() > 50 {
             Err(UserNameFuriganaError::TooLong.into())
         } else {
             Ok(UserNameFurigana(furigana.to_string()))

--- a/backend/domain/src/model/user_account/user_name_furigana.rs
+++ b/backend/domain/src/model/user_account/user_name_furigana.rs
@@ -41,8 +41,37 @@ impl std::str::FromStr for UserNameFurigana {
     }
 }
 
-#[test]
-fn test_user_furigana() {
-    let furigana = UserNameFurigana::new("イシダケンタロウ").unwrap();
-    assert_eq!(furigana.to_string(), "イシダケンタロウ");
+#[cfg(test)]
+mod test_user_name_furigana {
+    use super::*;
+
+    #[test]
+    fn ok() {
+        let furigana = UserNameFurigana::new("イシダケンタロウ").unwrap();
+        assert_eq!(furigana.to_string(), "イシダケンタロウ");
+    }
+
+    #[test]
+    fn empty() {
+        let furigana = UserNameFurigana::new("");
+        assert_eq!(furigana.is_err(), true);
+    }
+
+    #[test]
+    fn too_long() {
+        let furigana = UserNameFurigana::new("パブロ・ディエーゴ・ホセ・フランシスコ・デ・パウラ・ホアン・ネポムセーノ・マリーア・デ・ロス・レメディオス・クリスピーン・クリスピアーノ・デ・ラ・サンティシマ・トリニダード・ルイス・イ・ピカソ");
+        assert_eq!(furigana.is_err(), true);
+    }
+
+    #[test]
+    fn length_50() {
+        let furigana = UserNameFurigana::new("パブロ・ディエーゴ・ホセ・フランシスコ・デ・パウラ・ホアン・ネポムセーノ・マリーア・デ・ロス・レメデ");
+        assert_eq!(furigana.is_ok(), true);
+    }
+
+    #[test]
+    fn length_51() {
+        let furigana = UserNameFurigana::new("パブロ・ディエーゴ・ホセ・フランシスコ・デ・パウラ・ホアン・ネポムセーノ・マリーア・デ・ロス・レメディ");
+        assert_eq!(furigana.is_err(), true);
+    }
 }


### PR DESCRIPTION
## 対応する課題のチケット URL

- #28 
- #23 

## :question: 目的・背景(Why)

- 文字数カウントの方法を修正

## :up: 変更点(What)

- `backend/domain/src/model/user_account/user_name.rs`
- `backend/domain/src/model/user_account/user_name_furigana.rs`

## :pick: やったこと(How)

- 日本語の入力が想定される部分での文字数カウント方法を `str.len()` から `str.chars().count()` に修正
- テストコードの追加

## :red_circle: デプロイ・マイグレーション

- 特になし

## :camera_flash: （動作）確認内容・スクショ

![image](https://github.com/ishida-0622/VolunScout/assets/90295371/366ad2a0-c1e7-4733-a4c8-815edfe34074)

## :eyes: 重点的にレビューしてほしいところ・気になっているところ

- 特になし

close #23, close #28 