### PR TITLE
Feat backend group participant/#38

### DIFF
--- a/backend/command/infrastructure/src/activities/apply.rs
+++ b/backend/command/infrastructure/src/activities/apply.rs
@@ -7,7 +7,7 @@ use sqlx::MySqlPool;
 use command_repository::activities::apply::ApplyRepository;
 use domain::model::{
     apply::ApplyId,
-    user_account::user_id::UserId, volunteer::VolunteerId
+    user_account::user_id::UserId, volunteer::VolunteerId, group_participants::GroupParticipants, gender::{gender_from_i8, gender_to_i8}
 };
 
 pub struct ApplyImpl {
@@ -27,7 +27,8 @@ impl ApplyRepository for ApplyImpl {
         aid: ApplyId,
         vid: VolunteerId,
         user_id: UserId,
-        as_group: bool
+        as_group: bool,
+        members: Option<Vec<GroupParticipants>>
     ) -> Result<()> {
         let aid: String = aid.to_string();
         let vid: String = vid.to_string();
@@ -41,6 +42,32 @@ impl ApplyRepository for ApplyImpl {
             Utc::now(),
             as_group
         ).execute(&self.pool).await?;
+
+        match members {
+            Some(mems) => {
+                let insert_members_query: Vec<_> = mems
+                    .iter()
+                    .map(|gp: &GroupParticipants| {
+                        sqlx::query!(
+                            "INSERT INTO group_participants (gpid, serial, name, furigana, gender, age) VALUES (?, ?, ?, ?, ?, ?)",
+                            aid,
+                            gp.serial as i16,
+                            gp.name.to_string(),
+                            gp.furigana.to_string(),
+                            gender_to_i8(&gp.gender).unwrap(),
+                            gp.age as u8
+                        ).execute(&self.pool)
+                    })
+                    .collect::<Vec<_>>();
+
+                future::try_join_all(
+                    insert_members_query
+                        .into_iter()
+                )
+                .await?;
+            }
+            None => {}
+        }
 
         Ok(())
     }

--- a/backend/command/infrastructure/src/controllers/apply.rs
+++ b/backend/command/infrastructure/src/controllers/apply.rs
@@ -20,8 +20,6 @@ pub struct CreateApplyRequestBody {
     pub vid: String,
     #[schema(required = true)]
     pub uid: String,
-    #[schema(required = true)]
-    pub as_group: bool,
     pub members: Option<Vec<HashMap<String, Value>>>
 }
 
@@ -74,7 +72,6 @@ pub async fn create_apply(
         }
     };
 
-    let as_group: bool = body.as_group;
     let members: Option<Vec<GroupParticipants>> = if body.members != None {
         let mut return_member: Vec<GroupParticipants> = vec![];
         let m = body.members.unwrap();
@@ -179,6 +176,11 @@ pub async fn create_apply(
         Some(return_member)
     } else {
         None
+    };
+
+    let as_group: bool = match members {
+        None => {false}
+        Some(_) => true
     };
 
 

--- a/backend/command/infrastructure/src/controllers/apply.rs
+++ b/backend/command/infrastructure/src/controllers/apply.rs
@@ -179,7 +179,7 @@ pub async fn create_apply(
     };
 
     let as_group: bool = match members {
-        None => {false}
+        None => false,
         Some(_) => true
     };
 

--- a/backend/command/repository/src/activities/apply.rs
+++ b/backend/command/repository/src/activities/apply.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use domain::model::{
     apply::ApplyId,
     volunteer::VolunteerId,
-    user_account::user_id::UserId
+    user_account::user_id::UserId, group_participants::GroupParticipants
 };
 
 
@@ -16,7 +16,8 @@ pub trait ApplyRepository: Send + Sync {
         aid: ApplyId,
         vid: VolunteerId,
         user_id: UserId,
-        as_group: bool
+        as_group: bool,
+        members: Option<Vec<GroupParticipants>>
     ) -> Result<()>;
 
     /// 応募の承認を更新する

--- a/backend/domain/src/model/gender.rs
+++ b/backend/domain/src/model/gender.rs
@@ -35,3 +35,12 @@ pub fn gender_from_i8(arg: &i8) -> Result<Gender> {
         _ => Err(GenderError::NotFound.into()),
     }
 }
+
+pub fn gender_to_i8(arg: &Gender) -> Result<i8> {
+    match arg {
+        Gender::Male => Ok(Gender::Male as i8),
+        Gender::Female => Ok(Gender::Female as i8),
+        Gender::Other => Ok(Gender::Other as i8),
+        _ => Err(GenderError::NotFound.into())
+    }
+}

--- a/backend/domain/src/model/group_participants.rs
+++ b/backend/domain/src/model/group_participants.rs
@@ -4,7 +4,6 @@ use super::{user_account::{user_name::UserName, user_name_furigana::UserNameFuri
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroupParticipants {
-    pub gpid: ApplyId,
     pub serial: u16,
     pub name: UserName,
     pub furigana: UserNameFurigana,
@@ -14,7 +13,6 @@ pub struct GroupParticipants {
 
 impl GroupParticipants {
     pub fn new(
-        gpid: ApplyId,
         serial: u16,
         name: UserName,
         furigana: UserNameFurigana,
@@ -22,7 +20,6 @@ impl GroupParticipants {
         age: u8
     ) -> GroupParticipants {
         GroupParticipants{
-            gpid,
             serial,
             name,
             furigana,


### PR DESCRIPTION
## 対応する課題のチケット URL

#38 

## :question: 目的・背景(Why)

応募時の集団応募を可能にした

## :up: 変更点(What)

 - domain/src/model/group_participants.rsの修正
 - repository/src/activities/apply.rsのcreateへOption<Vec>の追加
 - infrastructure/src/controllers/apply.rsのcreate_applyへ上記Option<Vec>の追加
 - infrastructure/src/activities/apply.rsのcreateへgroup_participantsテーブルへのSQLを追加

## :red_circle: デプロイ・マイグレーション

- デプロイ時の注意点、マイグレーションが必要であれば記載

## :camera_flash: （動作）確認内容・スクショ

![image](https://github.com/ishida-0622/VolunScout/assets/97711353/db4c7178-2c86-4ff7-81e5-74e194f93b45)
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/dc336ba9-aafc-4dbe-92e0-c8bfeed865b0)

close #38