### PR TITLE
Feat backend group volunteer photos/#55

### DIFF
--- a/backend/command/infrastructure/src/activities/volunteer.rs
+++ b/backend/command/infrastructure/src/activities/volunteer.rs
@@ -37,6 +37,7 @@ impl VolunteerRepository for VolunteerImpl {
         as_group: bool,
         reward: Option<String>,
         terms: Terms,
+        s3_keys: Vec<String>
     ) -> Result<()> {
         let id: String = vid.to_string();
 
@@ -133,13 +134,26 @@ impl VolunteerRepository for VolunteerImpl {
             })
             .collect::<Vec<_>>();
 
+        let insert_photo_query: Vec<_> = s3_keys
+            .iter()
+            .map(|p: &String| {
+                sqlx::query!(
+                    "INSERT INTO volunteer_photo VALUES (?, ?)",
+                    p,
+                    id
+                )
+                .execute(&self.pool)
+            })
+            .collect::<Vec<_>>();
+
         future::try_join_all(
             insert_region_query
                 .into_iter()
                 .chain(insert_theme_query)
                 .chain(insert_theme_required_query)
                 .chain(insert_condition_query)
-                .chain(insert_condition_required_query),
+                .chain(insert_condition_required_query)
+                .chain(insert_photo_query),
         )
         .await?;
 
@@ -160,6 +174,7 @@ impl VolunteerRepository for VolunteerImpl {
         as_group: bool,
         reward: Option<String>,
         terms: Terms,
+        s3_keys: Vec<String>
     ) -> Result<()> {
         let id: String = vid.to_string();
 
@@ -186,7 +201,10 @@ impl VolunteerRepository for VolunteerImpl {
         let delete_element_query =
             sqlx::query!("DELETE FROM volunteer_element WHERE vid = ?", id).execute(&self.pool);
 
-        future::try_join3(update_query, delete_region_query, delete_element_query).await?;
+        let delete_photo_query =
+            sqlx::query!("DELETE FROM volunteer_photo WHERE vid = ?", id).execute(&self.pool);
+
+        future::try_join4(update_query, delete_region_query, delete_element_query, delete_photo_query).await?;
 
         sqlx::query!(
             "INSERT INTO volunteer_element (vid, eid) VALUES (?, ?)",
@@ -263,16 +281,28 @@ impl VolunteerRepository for VolunteerImpl {
             })
             .collect::<Vec<_>>();
 
+        let insert_photo_query: Vec<_> = s3_keys
+            .iter()
+            .map(|p: &String| {
+                sqlx::query!(
+                    "INSERT INTO volunteer_photo VALUES (?, ?)",
+                    p,
+                    id
+                )
+                .execute(&self.pool)
+            })
+            .collect::<Vec<_>>();
+
         future::try_join_all(
             insert_region_query
                 .into_iter()
                 .chain(insert_theme_query)
                 .chain(insert_theme_required_query)
                 .chain(insert_condition_query)
-                .chain(insert_condition_required_query),
+                .chain(insert_condition_required_query)
+                .chain(insert_photo_query),
         )
         .await?;
-
         Ok(())
     }
 

--- a/backend/command/infrastructure/src/controllers/group.rs
+++ b/backend/command/infrastructure/src/controllers/group.rs
@@ -31,6 +31,7 @@ pub struct CreateGroupAccountRequestBody {
     pub address: String,
     #[schema(required = true)]
     pub contents: String,
+    pub photos: Option<Vec<String>>,
 }
 
 /// グループアカウントの更新時のリクエストボディを表す構造体
@@ -52,6 +53,7 @@ pub struct UpdateGroupAccountRequestBody {
     pub address: String,
     #[schema(required = true)]
     pub contents: String,
+    pub photos: Option<Vec<String>>,
 }
 
 /// グループアカウントの削除時のリクエストボディを表す構造体
@@ -165,8 +167,13 @@ pub async fn create_group_account(
 
     let contents: String = body.contents;
 
+    let s3_keys: Vec<String> = match body.photos {
+        None => Vec::new(),
+        Some(s3_keys) => s3_keys
+    };
+
     match repository
-        .create(gid, name, furigana, representative_name, representative_furigana, phone, address, contents)
+        .create(gid, name, furigana, representative_name, representative_furigana, phone, address, contents, s3_keys)
         .await
     {
         Ok(_) => (
@@ -293,8 +300,13 @@ pub async fn update_group_account(
 
     let contents: String = body.contents;
 
+    let s3_keys: Vec<String> = match body.photos {
+        None => Vec::new(),
+        Some(s3_keys) => s3_keys
+    };
+
     match repository
-        .update(gid, name, furigana, representative_name, representative_furigana, phone, address, contents)
+        .update(gid, name, furigana, representative_name, representative_furigana, phone, address, contents, s3_keys)
         .await
     {
         Ok(_) => (

--- a/backend/command/infrastructure/src/controllers/volunteer.rs
+++ b/backend/command/infrastructure/src/controllers/volunteer.rs
@@ -50,6 +50,7 @@ pub struct CreateVolunteerRequestBody {
     pub reward: Option<String>,
     #[schema(required = true)]
     pub target_status: String,
+    pub photos: Option<Vec<String>>,
 }
 
 /// ボランティアの更新時のリクエストボディを表す構造体
@@ -91,6 +92,7 @@ pub struct UpdateVolunteerRequestBody {
     pub reward: Option<String>,
     #[schema(required = true)]
     pub target_status: String,
+    pub photos: Option<Vec<String>>,
 }
 
 /// ボランティアの削除時のリクエストボディを表す構造体
@@ -209,6 +211,11 @@ pub async fn create_volunteer(
         target_status,
     );
 
+    let s3_keys: Vec<String> = match body.photos {
+        None => Vec::new(),
+        Some(s3_keys) => s3_keys
+    };
+
     match repository
         .create(
             vid,
@@ -224,6 +231,7 @@ pub async fn create_volunteer(
             as_group,
             reward,
             terms,
+            s3_keys
         )
         .await
     {
@@ -324,6 +332,11 @@ pub async fn update_volunteer(
         target_status,
     );
 
+    let s3_keys: Vec<String> = match body.photos {
+        None => Vec::new(),
+        Some(s3_keys) => s3_keys
+    };
+
     match repository
         .update(
             vid,
@@ -338,6 +351,7 @@ pub async fn update_volunteer(
             as_group,
             reward,
             terms,
+            s3_keys
         )
         .await
     {

--- a/backend/command/infrastructure/src/user_account/group.rs
+++ b/backend/command/infrastructure/src/user_account/group.rs
@@ -61,7 +61,7 @@ impl GroupUserRepository for GroupAccountImpl {
             })
             .collect::<Vec<_>>();
 
-        future::try_join_all(insert_photo_query).await?;
+        future::try_join_all(insert_photo_query.into_iter()).await?;
 
         Ok(())
     }
@@ -94,7 +94,7 @@ impl GroupUserRepository for GroupAccountImpl {
         .await?;
 
         sqlx::query!(
-            "DELETE FROM group_account WHERE gid = ?",
+            "DELETE FROM group_photo WHERE gid = ?",
             id
         )
         .execute(&self.pool)
@@ -112,7 +112,7 @@ impl GroupUserRepository for GroupAccountImpl {
             })
             .collect::<Vec<_>>();
 
-        future::try_join_all(insert_photo_query).await?;
+        future::try_join_all(insert_photo_query.into_iter()).await?;
 
         Ok(())
     }

--- a/backend/command/repository/src/activities/volunteer.rs
+++ b/backend/command/repository/src/activities/volunteer.rs
@@ -27,6 +27,7 @@ pub trait VolunteerRepository: Send + Sync {
         as_group: bool,
         reward: Option<String>,
         terms: Terms,
+        photo_keys: Vec<String>
     ) -> Result<()>;
 
     /// ボランティアを更新する
@@ -44,6 +45,7 @@ pub trait VolunteerRepository: Send + Sync {
         as_group: bool,
         reward: Option<String>,
         terms: Terms,
+        photo_keys: Vec<String>
     ) -> Result<()>;
 
     /// ボランティアを削除する

--- a/backend/command/repository/src/user_account/group.rs
+++ b/backend/command/repository/src/user_account/group.rs
@@ -19,6 +19,7 @@ pub trait GroupUserRepository: Send + Sync {
         phone: UserPhone,
         address: String,
         contents: String,
+        photo_keys: Vec<String>
     ) -> Result<()>;
 
     /// 団体アカウントを更新する
@@ -32,6 +33,7 @@ pub trait GroupUserRepository: Send + Sync {
         phone: UserPhone,
         address: String,
         contents: String,
+        photo_keys: Vec<String>
     ) -> Result<()>;
 
     /// 団体アカウントを削除する

--- a/backend/tools/sql/init-insert.sql
+++ b/backend/tools/sql/init-insert.sql
@@ -249,36 +249,36 @@ INSERT INTO participant_review VALUES (
 );
 
 INSERT INTO group_photo VALUES (
-  "group/group0_1.png",
+  "photo/group/group0_1.png",
   "group_account000000000000000"
 );
 
 INSERT INTO group_photo VALUES (
-  "group/group0_2.png",
+  "photo/group/group0_2.png",
   "group_account000000000000000"
 );
 
 INSERT INTO group_photo VALUES (
-  "group/group1_0.png",
+  "photo/group/group1_0.png",
   "group_account000000000000001"
 );
 
 INSERT INTO group_photo VALUES (
-  "group/group1_1.png",
+  "photo/group/group1_1.png",
   "group_account000000000000001"
 );
 
 INSERT INTO volunteer_photo VALUES (
-  "volunteer/volunteer0_0.png",
+  "photo/volunteer/volunteer0_0.png",
   "01HKXVVVKBR6G8240N7HWSPR7M"
 );
 
 INSERT INTO volunteer_photo VALUES (
-  "volunteer/volunteer0_1.png",
+  "photo/volunteer/volunteer0_1.png",
   "01HKXVVVKBR6G8240N7HWSPR7M"
 );
 
 INSERT INTO volunteer_photo VALUES (
-  "volunteer/volunteer1_0.png",
+  "photo/volunteer/volunteer1_0.png",
   "01HKXZRM5AF35HHXJ8284PN0B7"
 );

--- a/backend/tools/sql/init-insert.sql
+++ b/backend/tools/sql/init-insert.sql
@@ -36,6 +36,20 @@ INSERT INTO group_account VALUES (
   NULL
 );
 
+INSERT INTO group_account VALUES (
+  "group_account000000000000001",
+  "VolunScoutSub",
+  "boran sukauto sabu",
+  "09012345678",
+  "Kanagawa",
+  "Nice to meet you",
+  "sakamoto",
+  "sakamoto",
+  DEFAULT,
+  DEFAULT,
+  NULL
+);
+
 INSERT INTO volunteer(
   vid,
   gid,
@@ -234,37 +248,37 @@ INSERT INTO participant_review VALUES (
   NULL
 );
 
-INSERT INTO group_volunteer_photo VALUES (
+INSERT INTO group_photo VALUES (
   "group/group0_1.png",
   "group_account000000000000000"
 );
 
-INSERT INTO group_volunteer_photo VALUES (
+INSERT INTO group_photo VALUES (
   "group/group0_2.png",
   "group_account000000000000000"
 );
 
-INSERT INTO group_volunteer_photo VALUES (
+INSERT INTO group_photo VALUES (
   "group/group1_0.png",
   "group_account000000000000001"
 );
 
-INSERT INTO group_volunteer_photo VALUES (
+INSERT INTO group_photo VALUES (
   "group/group1_1.png",
   "group_account000000000000001"
 );
 
-INSERT INTO group_volunteer_photo VALUES (
+INSERT INTO volunteer_photo VALUES (
   "volunteer/volunteer0_0.png",
   "01HKXVVVKBR6G8240N7HWSPR7M"
 );
 
-INSERT INTO group_volunteer_photo VALUES (
+INSERT INTO volunteer_photo VALUES (
   "volunteer/volunteer0_1.png",
   "01HKXVVVKBR6G8240N7HWSPR7M"
 );
 
-INSERT INTO group_volunteer_photo VALUES (
+INSERT INTO volunteer_photo VALUES (
   "volunteer/volunteer1_0.png",
   "01HKXZRM5AF35HHXJ8284PN0B7"
 );

--- a/backend/tools/sql/init-insert.sql
+++ b/backend/tools/sql/init-insert.sql
@@ -233,3 +233,38 @@ INSERT INTO participant_review VALUES (
   5,
   NULL
 );
+
+INSERT INTO group_volunteer_photo VALUES (
+  "group/group0_1.png",
+  "group_account000000000000000"
+);
+
+INSERT INTO group_volunteer_photo VALUES (
+  "group/group0_2.png",
+  "group_account000000000000000"
+);
+
+INSERT INTO group_volunteer_photo VALUES (
+  "group/group1_0.png",
+  "group_account000000000000001"
+);
+
+INSERT INTO group_volunteer_photo VALUES (
+  "group/group1_1.png",
+  "group_account000000000000001"
+);
+
+INSERT INTO group_volunteer_photo VALUES (
+  "volunteer/volunteer0_0.png",
+  "01HKXVVVKBR6G8240N7HWSPR7M"
+);
+
+INSERT INTO group_volunteer_photo VALUES (
+  "volunteer/volunteer0_1.png",
+  "01HKXVVVKBR6G8240N7HWSPR7M"
+);
+
+INSERT INTO group_volunteer_photo VALUES (
+  "volunteer/volunteer1_0.png",
+  "01HKXZRM5AF35HHXJ8284PN0B7"
+);

--- a/backend/tools/sql/up.sql
+++ b/backend/tools/sql/up.sql
@@ -168,9 +168,18 @@ CREATE TABLE IF NOT EXISTS `participant_review`
   FOREIGN KEY(`uid`) REFERENCES `participant_account`(`uid`)
 );
 
-CREATE TABLE IF NOT EXISTS `group_volunteer_photo`
+CREATE TABLE IF NOT EXISTS `group_photo`
 (
   `s3_key` VARCHAR(100),
-  `gvid` VARCHAR(28) NOT NULL,
-  PRIMARY KEY (`s3_key`)
+  `gid` CHAR(28) NOT NULL,
+  PRIMARY KEY (`s3_key`),
+  FOREIGN KEY(`gid`) REFERENCES `group_account`(`gid`)
+);
+
+CREATE TABLE IF NOT EXISTS `volunteer_photo`
+(
+  `s3_key` VARCHAR(100),
+  `vid` CHAR(26) NOT NULL,
+  PRIMARY KEY (`s3_key`),
+  FOREIGN KEY(`vid`) REFERENCES `volunteer`(`vid`)
 );


### PR DESCRIPTION
## 対応する課題のチケット URL

#55 

## :question: 目的・背景(Why)

- 団体情報・ボランティア情報に関連付いた写真を追加・変更できる機能の実装
- group_volunteer_photoテーブルを分割

## :up: 変更点(What)

- sql/up.insert.sqlの変更
- sql/init-insert.sqlへgroup_photo・volunteer_photo関連の作成
- repository/src/user_account/group.rs・activities/volunteer.rsへVec (s3key)の追記
- infrastructure/src/controllers/group.rs・volunteer.rsへVec (s3key)の追記
- infrastructure/src/user_account/group.rs・activities/volunteer.rsへVec (s3key)とgid・vidを用いたgroup_photo・volunteer_photoへのクエリを追記

## :camera_flash: （動作）確認内容・スクショ
- ボランティアへの画像追加 複数の写真
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/6298b246-ed7b-4a42-b7ea-e52778351c8a)
- ボランティアへの画像変更 photos要素がnullの場合(写真無しの場合)
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/7e76733a-47be-4819-84f3-06a789e00d2b)
- 団体への画像追加 単体の写真
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/a33891e1-3632-4bf2-bed2-c25f62c3e063)
- 団体への画像変更 単体の写真
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/5ed55f24-ce71-4a58-b495-af312b053461)


close #55