### PR TITLE
feat: implement group_account's switching plan

### DIFF
--- a/backend/command/infrastructure/src/controllers.rs
+++ b/backend/command/infrastructure/src/controllers.rs
@@ -61,6 +61,7 @@ pub enum Endpoints {
     CreateGroupAccount,
     UpdateGroupAccount,
     DeleteGroupAccount,
+    SwitchGroupAccountPlan,
     CreateParticipantAccount,
     UpdateParticipantAccount,
     DeleteParticipantAccount,
@@ -86,6 +87,7 @@ impl Endpoints {
             Endpoints::CreateGroupAccount => "/group-account/create",
             Endpoints::UpdateGroupAccount => "/group-account/update",
             Endpoints::DeleteGroupAccount => "/group-account/delete",
+            Endpoints::SwitchGroupAccountPlan => "/group-account/switch-plan",
             Endpoints::CreateParticipantAccount => "/participant-account/create",
             Endpoints::UpdateParticipantAccount => "/participant-account/update",
             Endpoints::DeleteParticipantAccount => "/participant-account/delete",
@@ -124,6 +126,10 @@ pub fn create_router(pool: MySqlPool) -> Router {
         .route(
             Endpoints::DeleteGroupAccount.as_str(),
             post(group::delete_group_account),
+        )
+        .route(
+            Endpoints::SwitchGroupAccountPlan.as_str(),
+            post(group::switch_group_account_plan),
         )
         .route(
             Endpoints::CreateParticipantAccount.as_str(),

--- a/backend/command/infrastructure/src/user_account/group.rs
+++ b/backend/command/infrastructure/src/user_account/group.rs
@@ -75,6 +75,17 @@ impl GroupUserRepository for GroupAccountImpl {
         Ok(())
     }
 
+    async fn switch_plan(&self, gid: UserId, is_paid: bool) -> Result<()> {
+        sqlx::query!(
+            "UPDATE group_account SET is_paid = ? WHERE gid = ?",
+            is_paid,
+            gid.to_string()
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     async fn delete(&self, gid: UserId) -> Result<()> {
         sqlx::query!(
             "UPDATE group_account SET is_deleted = true, deleted_at = ? WHERE gid = ?",

--- a/backend/command/repository/src/user_account/group.rs
+++ b/backend/command/repository/src/user_account/group.rs
@@ -34,6 +34,13 @@ pub trait GroupUserRepository: Send + Sync {
         contents: String,
     ) -> Result<()>;
 
+    /// 団体アカウントの有償・無償プランを変更する
+    async fn switch_plan(
+        &self,
+        gid: UserId,
+        is_paid: bool
+    ) -> Result<()>;
+
     /// 団体アカウントを削除する
     async fn delete(&self, gid: UserId) -> Result<()>;
 }


### PR DESCRIPTION
## 対応する課題のチケット URL

#61 

## :question: 目的・背景(Why)

- 団体が有償プランへ変更する、若しくは無償プランへ戻す機能の実装

## :up: 変更点(What)

- repository/src/user_account/group.rsへswitch_planの追記
- infrastructure/src/controllers/group.rsへswitch_planの追記
- infrastructure/src/user_account/group.rsへswitch_planのクエリを追記
- infrastructure/src/controllers.rsへSwitchGroupAccountPlanのエンドポイントを追記、各種ルーティングを設定

## :camera_flash: （動作）確認内容・スクショ

- 無償=>有償プランへの変更
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/c3574d9c-8308-4393-b4bf-628268c8cc56)
- 有償=>無償プランへの変更
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/1023a01f-944a-4a95-ac61-658eba817c32)

close #61