### PR TITLE
feat: implement scout functions of read-server

### DIFF
--- a/backend/query/infrastructure/src/activities.rs
+++ b/backend/query/infrastructure/src/activities.rs
@@ -1,0 +1,1 @@
+pub mod scout;

--- a/backend/query/infrastructure/src/activities/scout.rs
+++ b/backend/query/infrastructure/src/activities/scout.rs
@@ -18,10 +18,6 @@ impl ScoutImpl {
 #[async_trait]
 impl ScoutRepository for ScoutImpl {
     async fn find_by_sid(&self, sid: &ScoutId) -> Result<Scout> {
-        // sqlx::query!("SET log_statements = ON")
-        // .execute(&self.pool)
-        // .await?;
-
         let scout: Scout = sqlx::query_as!(
             Scout,
             r#"
@@ -34,10 +30,6 @@ impl ScoutRepository for ScoutImpl {
         )
         .fetch_one(&self.pool)
         .await?;
-    // sqlx::query!("SET log_statements = OFF")?
-    //     .execute(&self.pool)
-    //     .await?;
-
         Ok(scout)
     }
 

--- a/backend/query/infrastructure/src/activities/scout.rs
+++ b/backend/query/infrastructure/src/activities/scout.rs
@@ -81,18 +81,4 @@ impl ScoutRepository for ScoutImpl {
         .await?;
         Ok(scout)
     }
-
-    async fn find_all(&self) -> Result<Vec<Scout>> {
-        let scout = sqlx::query_as!(
-            Scout,
-            r#"
-            SELECT
-                sid, vid, uid, message, scouted_at, is_read as "is_read: bool", is_sent as "is_sent: bool", sent_at, is_denied as "is_denied: bool", denied_at
-            FROM scout
-            "#
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(scout)
-    }
 }

--- a/backend/query/infrastructure/src/activities/scout.rs
+++ b/backend/query/infrastructure/src/activities/scout.rs
@@ -1,0 +1,106 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::MySqlPool;
+
+use domain::model::{user_account::user_id::UserId, scout::ScoutId, volunteer::VolunteerId};
+use query_repository::activities::scout::{Scout, ScoutRepository};
+
+pub struct ScoutImpl {
+    pool: MySqlPool,
+}
+
+impl ScoutImpl {
+    pub fn new(pool: MySqlPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ScoutRepository for ScoutImpl {
+    async fn find_by_sid(&self, sid: &ScoutId) -> Result<Scout> {
+        // sqlx::query!("SET log_statements = ON")
+        // .execute(&self.pool)
+        // .await?;
+
+        let scout: Scout = sqlx::query_as!(
+            Scout,
+            r#"
+            SELECT
+                sid, vid, uid, message, scouted_at, is_read as "is_read: bool", is_sent as "is_sent: bool", sent_at, is_denied as "is_denied: bool", denied_at
+            FROM scout
+            WHERE sid = ?
+            "#,
+            sid.to_string()
+        )
+        .fetch_one(&self.pool)
+        .await?;
+    // sqlx::query!("SET log_statements = OFF")?
+    //     .execute(&self.pool)
+    //     .await?;
+
+        Ok(scout)
+    }
+
+    async fn find_by_gid(&self, gid: &UserId) -> Result<Vec<Scout>> {
+        let scout = sqlx::query_as!(
+            Scout,
+            r#"
+            SELECT
+                sid, vid, uid, message, scouted_at, is_read as "is_read: bool", is_sent as "is_sent: bool", sent_at, is_denied as "is_denied: bool", denied_at
+            FROM scout
+            WHERE vid IN
+                (select vid from volunteer where gid = ?)
+            "#,
+            gid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(scout)
+    }
+
+    async fn find_by_uid(&self, uid: &UserId) -> Result<Vec<Scout>> {
+        let scout = sqlx::query_as!(
+            Scout,
+            r#"
+            SELECT
+                sid, vid, uid, message, scouted_at, is_read as "is_read: bool", is_sent as "is_sent: bool", sent_at, is_denied as "is_denied: bool", denied_at
+            FROM scout
+            WHERE uid = ?
+            "#,
+            uid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(scout)
+    }
+
+    async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Scout>> {
+        let scout = sqlx::query_as!(
+            Scout,
+            r#"
+            SELECT
+                sid, vid, uid, message, scouted_at, is_read as "is_read: bool", is_sent as "is_sent: bool", sent_at, is_denied as "is_denied: bool", denied_at
+            FROM scout
+            WHERE vid = ?
+            "#,
+            vid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(scout)
+    }
+
+    async fn find_all(&self) -> Result<Vec<Scout>> {
+        let scout = sqlx::query_as!(
+            Scout,
+            r#"
+            SELECT
+                sid, vid, uid, message, scouted_at, is_read as "is_read: bool", is_sent as "is_sent: bool", sent_at, is_denied as "is_denied: bool", denied_at
+            FROM scout
+            "#
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(scout)
+    }
+}

--- a/backend/query/infrastructure/src/lib.rs
+++ b/backend/query/infrastructure/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod controllers;
 pub mod resolvers;
 pub mod user_account;
+pub mod activities;

--- a/backend/query/infrastructure/src/resolvers.rs
+++ b/backend/query/infrastructure/src/resolvers.rs
@@ -8,30 +8,33 @@ use async_graphql::{
 use redis::Client;
 use sqlx::MySqlPool;
 
-use domain::model::user_account::user_id::UserId;
-use query_repository::user_account::{
+use domain::model::{user_account::user_id::UserId, scout::ScoutId, volunteer::VolunteerId};
+use query_repository::{user_account::{
     group::{GroupAccount, GroupUserRepository},
     participant::{
         ParticipantAccount, ParticipantCondition, ParticipantRegion, ParticipantTargetStatus,
         ParticipantTheme, ParticipantUserRepository,
     },
-};
+}, activities::scout::{ScoutRepository, Scout}};
 
-use crate::user_account::{group::GroupAccountImpl, participant::ParticipantAccountImpl};
+use crate::{user_account::{group::GroupAccountImpl, participant::ParticipantAccountImpl}, activities::scout::ScoutImpl};
 
 pub struct ServiceContext {
     group_account_dao: Arc<dyn GroupUserRepository>,
     participant_account_dao: Arc<dyn ParticipantUserRepository>,
+    scout_dao: Arc<dyn ScoutRepository>
 }
 
 impl ServiceContext {
     pub fn new(
         group_account_dao: Arc<dyn GroupUserRepository>,
         participant_account_dao: Arc<dyn ParticipantUserRepository>,
+        scout_dao: Arc<dyn ScoutRepository>
     ) -> Self {
         Self {
             group_account_dao,
             participant_account_dao,
+            scout_dao
         }
     }
 }
@@ -240,6 +243,86 @@ impl QueryRoot {
 
         Ok(exists)
     }
+
+    /// 指定されたsidのスカウト情報を取得する
+    ///
+    /// ## 引数
+    /// - `sid` - sid
+    ///
+    /// ## 返り値
+    /// - `Scout` - スカウト情報
+    async fn get_scout_by_sid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        sid: String,
+    ) -> Result<Scout> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let sid: ScoutId = ScoutId::from_str(&sid);
+        let scout: Scout =
+            ctx.scout_dao.find_by_sid(&sid).await?;
+
+        Ok(scout)
+    }
+
+    /// 指定されたgidの団体が登録したボランティアのスカウト情報を取得する
+    ///
+    /// ## 引数
+    /// - `gid` - gid
+    ///
+    /// ## 返り値
+    /// - `Vec<Scout>` - スカウト情報の配列
+    async fn get_scout_by_gid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        gid: String,
+    ) -> Result<Vec<Scout>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let gid: UserId = UserId::new(&gid).unwrap();
+        let scout: Vec<Scout> =
+            ctx.scout_dao.find_by_gid(&gid).await?;
+
+        Ok(scout)
+    }
+
+    /// 指定されたvidのスカウト情報を取得する
+    ///
+    /// ## 引数
+    /// - `vid` - vid
+    ///
+    /// ## 返り値
+    /// - `Vec<Scout>` - スカウト情報の配列
+    async fn get_scout_by_vid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        vid: String,
+    ) -> Result<Vec<Scout>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let vid: VolunteerId = VolunteerId::from_str(&vid);
+        let scout: Vec<Scout> =
+            ctx.scout_dao.find_by_vid(&vid).await?;
+
+        Ok(scout)
+    }
+
+    /// 指定されたuidに送られたスカウト情報を取得する
+    ///
+    /// ## 引数
+    /// - `uid` - uid
+    ///
+    /// ## 返り値
+    /// - `Vec<Scout>` - スカウト情報の配列
+    async fn get_scout_by_uid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        uid: String,
+    ) -> Result<Vec<Scout>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let uid: UserId = UserId::new(&uid).unwrap();
+        let scout: Vec<Scout> =
+            ctx.scout_dao.find_by_uid(&uid).await?;
+
+        Ok(scout)
+    }
 }
 
 pub struct SubscriptionRoot;
@@ -265,10 +348,12 @@ pub fn create_schema_builder() -> SchemaBuilder<QueryRoot, EmptyMutation, Subscr
 pub fn create_schema(pool: MySqlPool) -> ApiSchema {
     let group_account_dao: GroupAccountImpl = GroupAccountImpl::new(pool.clone());
     let participant_account_dao: ParticipantAccountImpl = ParticipantAccountImpl::new(pool.clone());
+    let scout_dao: ScoutImpl = ScoutImpl::new(pool.clone());
 
     let ctx: ServiceContext = ServiceContext::new(
         Arc::new(group_account_dao),
         Arc::new(participant_account_dao),
+        Arc::new(scout_dao)
     );
 
     create_schema_builder().data(ctx).finish()

--- a/backend/query/repository/src/activities.rs
+++ b/backend/query/repository/src/activities.rs
@@ -1,0 +1,1 @@
+pub mod scout;

--- a/backend/query/repository/src/activities/scout.rs
+++ b/backend/query/repository/src/activities/scout.rs
@@ -71,7 +71,4 @@ pub trait ScoutRepository: Send + Sync {
 
     /// スカウト情報をボランティアIDで一括取得する
     async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Scout>>;
-
-    /// スカウト情報を全て取得する
-    async fn find_all(&self) -> Result<Vec<Scout>>;
 }

--- a/backend/query/repository/src/activities/scout.rs
+++ b/backend/query/repository/src/activities/scout.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use async_graphql::SimpleObject;
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+
+use domain::model::{user_account::user_id::UserId, scout::ScoutId, volunteer::VolunteerId};
+
+/// スカウトリードモデル
+#[derive(SimpleObject, sqlx::Type)]
+pub struct Scout {
+    // スカウトID
+    pub sid: String,
+    // ボランティアID
+    pub vid: String,
+    // 参加者ID
+    pub uid: String,
+    // スカウトメッセージ
+    pub message: String,
+    // スカウト日時
+    pub scouted_at: NaiveDateTime,
+    // 既読有無
+    pub is_read: bool,
+    // スカウトメール送信有無
+    pub is_sent: bool,
+    // スカウトメール送信日時
+    pub sent_at: Option<NaiveDateTime>,
+    // 辞退有無
+    pub is_denied: bool,
+    // 辞退日時
+    pub denied_at: Option<NaiveDateTime>
+}
+
+impl Scout {
+    pub fn new(
+        sid: String,
+        vid: String,
+        uid: String,
+        message: String,
+        scouted_at: NaiveDateTime,
+        is_read: bool,
+        is_sent: bool,
+        sent_at: Option<NaiveDateTime>,
+        is_denied: bool,
+        denied_at: Option<NaiveDateTime>
+    ) -> Scout {
+        Scout {
+            sid,
+            vid,
+            uid,
+            message,
+            scouted_at,
+            is_read,
+            is_sent,
+            sent_at,
+            is_denied,
+            denied_at
+        }
+    }
+}
+
+#[async_trait]
+pub trait ScoutRepository: Send + Sync {
+    /// スカウト情報をスカウトIDで取得する
+    async fn find_by_sid(&self, sid: &ScoutId) -> Result<Scout>;
+
+    /// スカウト情報を団体IDで一括取得する
+    async fn find_by_gid(&self, gid: &UserId) -> Result<Vec<Scout>>;
+
+    /// スカウト情報を参加者IDで一括取得する
+    async fn find_by_uid(&self, uid: &UserId) -> Result<Vec<Scout>>;
+
+    /// スカウト情報をボランティアIDで一括取得する
+    async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Scout>>;
+
+    /// スカウト情報を全て取得する
+    async fn find_all(&self) -> Result<Vec<Scout>>;
+}

--- a/backend/query/repository/src/lib.rs
+++ b/backend/query/repository/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod user_account;
+pub mod activities;


### PR DESCRIPTION
## 対応する課題のチケット URL

#65 

## :question: 目的・背景(Why)

read serverのスカウト周り実装

## :up: 変更点(What)

read serverの以下のクエリを実装
- getScoutBySid(sid) スカウトIDの一致するスカウト情報を取得
- getScoutByGid(gid) 団体IDが一致する、団体が登録したボランティアのスカウト情報を取得
- getScoutByVid(vid) ボランティアIDが一致するボランティアのスカウト情報を取得
- getScoutByUid(uid) 参加者IDが一致する参加者に送られたスカウト情報を取得

## :pick: やったこと(How)

query
- ├repository/src/
- │　　　　　├activities/scout.rs
- │　　　　　├lib.rs(activitiesを追跡対象に変更)
- │　　　　　└activities.rs(scoutを追跡対象に変更)
- └repository/src/
-   　　　　　├activities/scout.rs
-   　　　　　├lib.rs(activitiesを追跡対象に変更)
-   　　　　　├activities.rs(scoutを追跡対象に変更)
-   　　　　　└resolvers.rs

## :red_circle: デプロイ・マイグレーション

- デプロイ時の注意点、マイグレーションが必要であれば記載

## :camera_flash: （動作）確認内容・スクショ

![image](https://github.com/ishida-0622/VolunScout/assets/97711353/fc4609f4-7d72-47e2-a136-162e25118641)
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/4880c8b5-41d1-4238-a927-9c70df3b8ff2)

close #65
