### PR TITLE
feat: implement functions of apply about read-server

### DIFF
--- a/backend/query/infrastructure/src/activities.rs
+++ b/backend/query/infrastructure/src/activities.rs
@@ -1,1 +1,2 @@
 pub mod scout;
+pub mod apply;

--- a/backend/query/infrastructure/src/activities/apply.rs
+++ b/backend/query/infrastructure/src/activities/apply.rs
@@ -1,0 +1,84 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::MySqlPool;
+
+use domain::model::{user_account::user_id::UserId, apply::ApplyId, volunteer::VolunteerId};
+use query_repository::activities::apply::{Apply, ApplyRepository};
+
+pub struct ApplyImpl {
+    pool: MySqlPool,
+}
+
+impl ApplyImpl {
+    pub fn new(pool: MySqlPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ApplyRepository for ApplyImpl {
+    async fn find_by_sid(&self, aid: &ApplyId) -> Result<Apply> {
+        let apply: Apply = sqlx::query_as!(
+            Apply,
+            r#"
+            SELECT
+                aid, vid, uid, applied_at, as_group as "as_group: bool", allowed_status, decided_at, is_sent as "is_sent: bool"
+            FROM apply
+            WHERE aid = ?
+            "#,
+            aid.to_string()
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(apply)
+    }
+
+    async fn find_by_gid(&self, gid: &UserId) -> Result<Vec<Apply>> {
+        let apply = sqlx::query_as!(
+            Apply,
+            r#"
+            SELECT
+                aid, vid, uid, applied_at, as_group as "as_group: bool", allowed_status, decided_at, is_sent as "is_sent: bool"
+            FROM apply
+            WHERE vid IN
+                (select vid from volunteer where gid = ?)
+            "#,
+            gid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(apply)
+    }
+
+    async fn find_by_uid(&self, uid: &UserId) -> Result<Vec<Apply>> {
+        let apply = sqlx::query_as!(
+            Apply,
+            r#"
+            SELECT
+                aid, vid, uid, applied_at, as_group as "as_group: bool", allowed_status, decided_at, is_sent as "is_sent: bool"
+            FROM apply
+            WHERE uid = ?
+            "#,
+            uid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(apply)
+    }
+
+    async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Apply>> {
+        let apply = sqlx::query_as!(
+            Apply,
+            r#"
+            SELECT
+                aid, vid, uid, applied_at, as_group as "as_group: bool", allowed_status, decided_at, is_sent as "is_sent: bool"
+            FROM apply
+            WHERE vid = ?
+            "#,
+            vid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(apply)
+    }
+}

--- a/backend/query/repository/src/activities.rs
+++ b/backend/query/repository/src/activities.rs
@@ -1,1 +1,2 @@
 pub mod scout;
+pub mod apply;

--- a/backend/query/repository/src/activities/apply.rs
+++ b/backend/query/repository/src/activities/apply.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use async_graphql::SimpleObject;
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+
+use domain::model::{user_account::user_id::UserId, apply::ApplyId, volunteer::VolunteerId};
+
+/// スカウトリードモデル
+#[derive(SimpleObject, sqlx::Type)]
+pub struct Apply {
+    /// 応募ID
+    pub aid: String,
+    /// ボランティアID
+    pub vid: String,
+    /// 参加者ID
+    pub uid: String,
+    /// 応募日時
+    pub applied_at: NaiveDateTime,
+    /// 集団応募有無
+    pub as_group: bool,
+    /// 認証データ
+    pub allowed_status: i8,
+    /// 認証日時
+    pub decided_at: Option<NaiveDateTime>,
+    /// 送信日時
+    pub is_sent: bool
+}
+
+impl Apply {
+    pub fn new(
+        aid: String,
+        vid: String,
+        uid: String,
+        applied_at: NaiveDateTime,
+        as_group: bool,
+        allowed_status: i8,
+        decided_at: Option<NaiveDateTime>,
+        is_sent: bool
+    ) -> Apply {
+        Apply {
+            aid,
+            vid,
+            uid,
+            applied_at,
+            as_group,
+            allowed_status,
+            decided_at,
+            is_sent,
+        }
+    }
+}
+
+#[async_trait]
+pub trait ApplyRepository: Send + Sync {
+    /// 応募情報を応募IDで取得する
+    async fn find_by_sid(&self, sid: &ApplyId) -> Result<Apply>;
+
+    /// 応募情報を団体IDで一括取得する
+    async fn find_by_gid(&self, gid: &UserId) -> Result<Vec<Apply>>;
+
+    /// 応募情報を参加者IDで一括取得する
+    async fn find_by_uid(&self, uid: &UserId) -> Result<Vec<Apply>>;
+
+    /// 応募情報をボランティアIDで一括取得する
+    async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Apply>>;
+}


### PR DESCRIPTION
## 対応する課題のチケット URL

#67 

## :question: 目的・背景(Why)

- 応募周辺のread serverへの実装

## :up: 変更点(What)

- getApplyByAid(aid) 応募IDの一致する応募情報を取得
- getApplyByGid(gid) 団体IDが一致する、団体が登録したボランティアの応募情報を取得
- getApplyByVid(vid) ボランティアIDが一致するボランティアの応募情報を取得
- getApplyByUid(uid) 参加者IDが一致する参加者が応募した応募情報を取得

## :pick: やったこと(How)

 - ├repository/src/
 - │　　　　　├activities/apply.rs
-  │　　　　　└activities.rs(applyを追跡対象に変更)
-  └repository/src/
-  　　　　　├activities/apply.rs
-  　　　　　├activities.rs(applyを追跡対象に変更)
-  　　　　　└resolvers.rs


## :camera_flash: （動作）確認内容・スクショ

![image](https://github.com/ishida-0622/VolunScout/assets/97711353/fff70020-a131-4539-861f-0e5198e8bb17)
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/7b02fa9c-bae2-4f57-831e-fa2708808eb4)


close #67 