### PR TITLE
feat: implement functions of review about read server

### DIFF
--- a/backend/query/infrastructure/src/activities.rs
+++ b/backend/query/infrastructure/src/activities.rs
@@ -1,3 +1,4 @@
 pub mod scout;
 pub mod apply;
 pub mod volunteer;
+pub mod review;

--- a/backend/query/infrastructure/src/activities/review.rs
+++ b/backend/query/infrastructure/src/activities/review.rs
@@ -1,0 +1,102 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::MySqlPool;
+
+use domain::model::{user_account::user_id::UserId, volunteer::VolunteerId};
+use query_repository::activities::review::{Review, ParticipantReviewRepository, VolunteerReviewRepository};
+
+pub struct ReviewImpl {
+    pool: MySqlPool,
+}
+
+impl ReviewImpl {
+    pub fn new(pool: MySqlPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ParticipantReviewRepository for ReviewImpl {
+    async fn find_by_ids(&self, uid: &UserId, vid: &VolunteerId) -> Result<Review> {
+        let review: Review = sqlx::query_as!(
+            Review,
+            r#"
+            SELECT * FROM participant_review WHERE uid = ? and vid = ?
+            "#,
+            uid.to_string(),
+            vid.to_string()
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(review)
+    }
+
+    async fn find_by_uid(&self, uid: &UserId) -> Result<Vec<Review>> {
+        let review = sqlx::query_as!(
+            Review,
+            r#"
+            SELECT * FROM participant_review WHERE uid = ?
+            "#,
+            uid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(review)
+    }
+
+    async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Review>> {
+        let review = sqlx::query_as!(
+            Review,
+            r#"
+            SELECT * FROM participant_review WHERE vid = ?
+            "#,
+            vid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(review)
+    }
+}
+
+#[async_trait]
+impl VolunteerReviewRepository for ReviewImpl {
+    async fn find_by_ids(&self, uid: &UserId, vid: &VolunteerId) -> Result<Review> {
+        let review: Review = sqlx::query_as!(
+            Review,
+            r#"
+            SELECT * FROM volunteer_review WHERE uid = ? and vid = ?
+            "#,
+            uid.to_string(),
+            vid.to_string()
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(review)
+    }
+
+    async fn find_by_uid(&self, uid: &UserId) -> Result<Vec<Review>> {
+        let review = sqlx::query_as!(
+            Review,
+            r#"
+            SELECT * FROM volunteer_review WHERE uid = ?
+            "#,
+            uid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(review)
+    }
+
+    async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Review>> {
+        let review = sqlx::query_as!(
+            Review,
+            r#"
+            SELECT * FROM volunteer_review WHERE vid = ?
+            "#,
+            vid.to_string()
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(review)
+    }
+}

--- a/backend/query/infrastructure/src/resolvers.rs
+++ b/backend/query/infrastructure/src/resolvers.rs
@@ -1,4 +1,4 @@
-use std::{iter::Rev, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 
 use anyhow::Result;
 use async_graphql::{

--- a/backend/query/infrastructure/src/resolvers.rs
+++ b/backend/query/infrastructure/src/resolvers.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::{iter::Rev, str::FromStr, sync::Arc};
 
 use anyhow::Result;
 use async_graphql::{
@@ -20,12 +20,13 @@ use query_repository::{
             scout::{ScoutRepository, Scout},
             apply::{Apply, ApplyRepository},
             volunteer::{VolunteerQueryRepository, VolunteerReadModel},
+            review::{Review, ParticipantReviewRepository, VolunteerReviewRepository}
         }
 };
 
 use crate::{
     user_account::{group::GroupAccountImpl, participant::ParticipantAccountImpl},
-    activities::{scout::ScoutImpl, apply::ApplyImpl, volunteer::VolunteerQueryRepositoryImpl}
+    activities::{scout::ScoutImpl, apply::ApplyImpl, volunteer::VolunteerQueryRepositoryImpl, review::ReviewImpl}
 };
 
 pub struct ServiceContext {
@@ -34,6 +35,8 @@ pub struct ServiceContext {
     scout_dao: Arc<dyn ScoutRepository>,
     apply_dao: Arc<dyn ApplyRepository>,
     volunteer_dao: Arc<dyn VolunteerQueryRepository>,
+    participant_review_dao: Arc<dyn ParticipantReviewRepository>,
+    volunteer_review_dao: Arc<dyn VolunteerReviewRepository>
 }
 
 impl ServiceContext {
@@ -43,6 +46,8 @@ impl ServiceContext {
         scout_dao: Arc<dyn ScoutRepository>,
         apply_dao: Arc<dyn ApplyRepository>,
         volunteer_dao: Arc<dyn VolunteerQueryRepository>,
+        participant_review_dao: Arc<dyn ParticipantReviewRepository>,
+        volunteer_review_dao: Arc<dyn VolunteerReviewRepository>
     ) -> Self {
         Self {
             group_account_dao,
@@ -50,6 +55,8 @@ impl ServiceContext {
             scout_dao,
             apply_dao,
             volunteer_dao,
+            participant_review_dao,
+            volunteer_review_dao
         }
     }
 }
@@ -436,6 +443,126 @@ impl QueryRoot {
 
         Ok(volunteers)
     }
+
+    /// 指定されたuidとvidの参加者レビュー情報を取得する
+    ///
+    /// ## 引数
+    /// - `uid` - uid
+    /// - `vid` - vid
+    ///
+    /// ## 返り値
+    /// - `Review` - レビュー情報
+    async fn get_participant_review_by_ids<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        uid: String,
+        vid: String
+    ) -> Result<Review> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let uid = UserId::from_str(&uid).unwrap();
+        let vid = VolunteerId::from_str(&vid);
+        let review: Review = ctx.participant_review_dao.find_by_ids(&uid, &vid).await?;
+
+        Ok(review)
+    }
+
+    /// 指定されたuidの参加者レビュー情報を取得する
+    ///
+    /// ## 引数
+    /// - `uid` - uid
+    ///
+    /// ## 返り値
+    /// - `Review` - レビュー情報
+    async fn get_participant_review_by_uid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        uid: String
+    ) -> Result<Vec<Review>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let uid = UserId::from_str(&uid).unwrap();
+        let review: Vec<Review> = ctx.participant_review_dao.find_by_uid(&uid).await?;
+
+        Ok(review)
+    }
+
+    /// 指定されたvidの参加者レビュー情報を取得する
+    ///
+    /// ## 引数
+    /// - `vid` - vid
+    ///
+    /// ## 返り値
+    /// - `Review` - レビュー情報
+    async fn get_participant_review_by_vid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        vid: String
+    ) -> Result<Vec<Review>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let vid = VolunteerId::from_str(&vid);
+        let review: Vec<Review> = ctx.participant_review_dao.find_by_vid(&vid).await?;
+
+        Ok(review)
+    }
+
+    /// 指定されたuidとvidのボランティアレビュー情報を取得する
+    ///
+    /// ## 引数
+    /// - `uid` - uid
+    /// - `vid` - vid
+    ///
+    /// ## 返り値
+    /// - `Review` - レビュー情報
+    async fn get_volunteer_review_by_ids<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        uid: String,
+        vid: String
+    ) -> Result<Review> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let uid = UserId::from_str(&uid).unwrap();
+        let vid = VolunteerId::from_str(&vid);
+        let review: Review = ctx.volunteer_review_dao.find_by_ids(&uid, &vid).await?;
+
+        Ok(review)
+    }
+
+    /// 指定されたuidのボランティアレビュー情報を取得する
+    ///
+    /// ## 引数
+    /// - `uid` - uid
+    ///
+    /// ## 返り値
+    /// - `Review` - レビュー情報
+    async fn get_volunteer_review_by_uid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        uid: String
+    ) -> Result<Vec<Review>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let uid = UserId::from_str(&uid).unwrap();
+        let review: Vec<Review> = ctx.volunteer_review_dao.find_by_uid(&uid).await?;
+
+        Ok(review)
+    }
+
+    /// 指定されたvidのボランティアレビュー情報を取得する
+    ///
+    /// ## 引数
+    /// - `vid` - vid
+    ///
+    /// ## 返り値
+    /// - `Review` - レビュー情報
+    async fn get_volunteer_review_by_vid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        vid: String
+    ) -> Result<Vec<Review>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let vid = VolunteerId::from_str(&vid);
+        let review: Vec<Review> = ctx.volunteer_review_dao.find_by_vid(&vid).await?;
+
+        Ok(review)
+    }
 }
 
 pub struct SubscriptionRoot;
@@ -465,14 +592,17 @@ pub fn create_schema(pool: MySqlPool) -> ApiSchema {
     let apply_dao: ApplyImpl = ApplyImpl::new(pool.clone());
     let volunteer_dao: VolunteerQueryRepositoryImpl =
         VolunteerQueryRepositoryImpl::new(pool.clone());
+    let participant_review_dao: ReviewImpl = ReviewImpl::new(pool.clone());
+    let volunteer_review_dao: ReviewImpl = ReviewImpl::new(pool.clone());
 
     let ctx: ServiceContext = ServiceContext::new(
         Arc::new(group_account_dao),
         Arc::new(participant_account_dao),
         Arc::new(scout_dao),
         Arc::new(apply_dao),
-        Arc::new(volunteer_dao)
-
+        Arc::new(volunteer_dao),
+        Arc::new(participant_review_dao),
+        Arc::new(volunteer_review_dao)
     );
 
     create_schema_builder().data(ctx).finish()

--- a/backend/query/repository/src/activities.rs
+++ b/backend/query/repository/src/activities.rs
@@ -1,3 +1,4 @@
 pub mod scout;
 pub mod apply;
 pub mod volunteer;
+pub mod review;

--- a/backend/query/repository/src/activities/review.rs
+++ b/backend/query/repository/src/activities/review.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_graphql::SimpleObject;
 use async_trait::async_trait;
 
-use domain::model::{user_account::user_id::UserId, scout::ScoutId, volunteer::VolunteerId};
+use domain::model::{user_account::user_id::UserId, volunteer::VolunteerId};
 
 /// レビューリードモデル
 #[derive(SimpleObject, sqlx::Type)]

--- a/backend/query/repository/src/activities/review.rs
+++ b/backend/query/repository/src/activities/review.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use async_graphql::SimpleObject;
+use async_trait::async_trait;
+
+use domain::model::{user_account::user_id::UserId, scout::ScoutId, volunteer::VolunteerId};
+
+/// レビューリードモデル
+#[derive(SimpleObject, sqlx::Type)]
+pub struct Review {
+    /// 参加者ID
+    pub uid: String,
+    /// ボランティアID
+    pub vid: String,
+    /// レビューポイント
+    pub point: i8,
+    /// コメント
+    pub comment: Option<String>
+}
+
+impl Review {
+    pub fn new(
+        uid: String,
+        vid: String,
+        point: i8,
+        comment: Option<String>
+    ) -> Review {
+        Review {
+            uid,
+            vid,
+            point,
+            comment
+        }
+    }
+}
+
+#[async_trait]
+pub trait ParticipantReviewRepository: Send + Sync {
+    /// 参加者へのレビュー情報を参加者IDとボランティアIDで1件取得する
+    async fn find_by_ids(&self, uid: &UserId, vid: &VolunteerId) -> Result<Review>;
+
+    /// 参加者へのレビュー情報を参加者IDで一括取得する
+    async fn find_by_uid(&self, uid: &UserId) -> Result<Vec<Review>>;
+
+    /// 参加者へのレビュー情報をボランティアIDで一括取得する
+    async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Review>>;
+}
+
+#[async_trait]
+pub trait VolunteerReviewRepository: Send + Sync {
+    /// ボランティアへのレビュー情報を参加者IDとボランティアIDで1件取得する
+    async fn find_by_ids(&self, uid: &UserId, vid: &VolunteerId) -> Result<Review>;
+
+    /// ボランティアへのレビュー情報を参加者IDで一括取得する
+    async fn find_by_uid(&self, uid: &UserId) -> Result<Vec<Review>>;
+
+    /// ボランティアへのレビュー情報をボランティアIDで一括取得する
+    async fn find_by_vid(&self, vid: &VolunteerId) -> Result<Vec<Review>>;
+}


### PR DESCRIPTION
## 対応する課題のチケット URL

#70 

## :question: 目的・背景(Why)

- read serverへのレビュー周辺機能の実装

## :up: 変更点(What)

　　├`repository/src/`
- │　　　　　├`activities/review.rs`
- │　　　　　└`activities.rs` (reviewを追跡対象に変更)
└`repository/src/`
-  　　　　 　├`activities/review.rs`
-  　　　　 　├`activities.rs` (reviewを追跡対象に変更)
-  　　　　 　└`resolvers.rs`

## :pick: やったこと(How)

以下のメソッドを実装
- getVolunteerReviewByIds(uid, vid) => 参加者IDとボランティアIDが一致する、ボランティアへのレビュー情報を1件取得
- getVolunteerReviewByUid(uid) => 参加者IDが一致する、ボランティアへのレビュー情報を全件取得
- getVolunteerReviewByVid(vid) => ボランティアIDが一致する、ボランティアへのレビュー情報を全件取得
- getParticipantReviewByIds(uid, vid) => 参加者IDとボランティアIDが一致する、参加者へのレビュー情報を1件取得
- getParticipantReviewByUid(uid) => 参加者IDが一致する、参加者へのレビュー情報を全件取得
- getParticipantReviewByVid(vid) => ボランティアIDが一致する、参加者へのレビュー情報を全件取得

## :camera_flash: （動作）確認内容・スクショ

![image](https://github.com/ishida-0622/VolunScout/assets/97711353/c4281f7b-ddc4-4e7b-8bbd-1bd7b3edeaaf)
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/6120894e-f0ab-4692-b1da-950b80ff1acc)


close #70 