### PR TITLE
Feat backend read complete participant/#80

### DIFF
--- a/backend/query/infrastructure/src/resolvers.rs
+++ b/backend/query/infrastructure/src/resolvers.rs
@@ -436,6 +436,63 @@ impl QueryRoot {
 
         Ok(volunteers)
     }
+
+    /// 指定されたuidがお気に入りに登録しているボランティア情報を取得する
+    ///
+    /// ## 引数
+    /// - `uid` - uid
+    ///
+    /// ## 返り値
+    /// - `Vec<VolunteerReadModel>` - ボランティア情報の配列
+    async fn get_favorite_by_uid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        uid: String,
+    ) -> Result<Vec<VolunteerReadModel>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let uid = UserId::from_str(&uid).unwrap();
+        let volunteers: Vec<VolunteerReadModel> = ctx.volunteer_dao.find_favorite_by_id(&uid).await?;
+
+        Ok(volunteers)
+    }
+
+    /// 指定されたuidが過去に活動したボランティア情報を取得する
+    ///
+    /// ## 引数
+    /// - `uid` - uid
+    ///
+    /// ## 返り値
+    /// - `Vec<VolunteerReadModel>` - ボランティア情報の配列
+    async fn get_activities_by_uid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        uid: String,
+    ) -> Result<Vec<VolunteerReadModel>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let uid = UserId::from_str(&uid).unwrap();
+        let volunteers: Vec<VolunteerReadModel> = ctx.volunteer_dao.find_activity_by_id(&uid).await?;
+
+        Ok(volunteers)
+    }
+
+    /// 指定されたuidがこれから活動を予定しているボランティア情報を取得する
+    ///
+    /// ## 引数
+    /// - `uid` - uid
+    ///
+    /// ## 返り値
+    /// - `Vec<VolunteerReadModel>` - ボランティア情報の配列
+    async fn get_scheduled_activities_by_uid<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        uid: String,
+    ) -> Result<Vec<VolunteerReadModel>> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let uid = UserId::from_str(&uid).unwrap();
+        let volunteers: Vec<VolunteerReadModel> = ctx.volunteer_dao.find_scheduled_activity_by_id(&uid).await?;
+
+        Ok(volunteers)
+    }
 }
 
 pub struct SubscriptionRoot;

--- a/backend/query/infrastructure/src/user_account/participant.rs
+++ b/backend/query/infrastructure/src/user_account/participant.rs
@@ -6,14 +6,15 @@ use domain::consts::themes::ThemeMap;
 use sqlx::MySqlPool;
 
 use domain::consts::region::RegionMap;
-use domain::model::{user_account::user_id::UserId, volunteer::Volunteer};
-use query_repository::user_account::participant::{
+use domain::model::user_account::user_id::UserId;
+use query_repository::
+    user_account::participant::{
     ParticipantAccount, ParticipantCondition, ParticipantRegion, ParticipantTargetStatus,
     ParticipantTheme, ParticipantUserRepository,
 };
 
 pub struct ParticipantAccountImpl {
-    pool: MySqlPool,
+    pool: MySqlPool
 }
 
 impl ParticipantAccountImpl {
@@ -151,18 +152,6 @@ impl ParticipantUserRepository for ParticipantAccountImpl {
         Ok(ParticipantTargetStatus {
             name: target_status,
         })
-    }
-
-    async fn find_favorite_by_id(&self, pid: &UserId) -> Result<Vec<Volunteer>> {
-        todo!()
-    }
-
-    async fn find_activity_by_id(&self, pid: &UserId) -> Result<Vec<Volunteer>> {
-        todo!()
-    }
-
-    async fn find_scheduled_activity_by_id(&self, pid: &UserId) -> Result<Vec<Volunteer>> {
-        todo!()
     }
 
     async fn exists(&self, pid: &UserId) -> Result<bool> {

--- a/backend/query/repository/src/activities/volunteer.rs
+++ b/backend/query/repository/src/activities/volunteer.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use chrono::{NaiveDate, NaiveDateTime};
 
 use domain::model::{user_account::user_id::UserId, volunteer::VolunteerId};
-
 /// ボランティアリードモデル
 #[derive(SimpleObject, sqlx::Type)]
 pub struct VolunteerReadModel {
@@ -88,4 +87,13 @@ pub trait VolunteerQueryRepository: Send + Sync {
 
     /// ボランティアをグループidで取得する
     async fn find_by_gid(&self, gid: &UserId) -> Result<Vec<VolunteerReadModel>>;
+
+    /// 参加者のお気に入りを取得する
+    async fn find_favorite_by_id(&self, pid: &UserId) -> Result<Vec<VolunteerReadModel>>;
+
+    /// 参加者の活動履歴を取得する
+    async fn find_activity_by_id(&self, pid: &UserId) -> Result<Vec<VolunteerReadModel>>;
+
+    /// 参加者の予定を取得する
+    async fn find_scheduled_activity_by_id(&self, pid: &UserId) -> Result<Vec<VolunteerReadModel>>;
 }

--- a/backend/query/repository/src/user_account/participant.rs
+++ b/backend/query/repository/src/user_account/participant.rs
@@ -3,7 +3,7 @@ use async_graphql::SimpleObject;
 use async_trait::async_trait;
 use chrono::{NaiveDate, NaiveDateTime};
 
-use domain::model::{user_account::user_id::UserId, volunteer::Volunteer};
+use domain::model::user_account::user_id::UserId;
 
 /// 参加者アカウントリードモデル
 #[derive(SimpleObject, sqlx::Type)]
@@ -80,15 +80,6 @@ pub trait ParticipantUserRepository: Send + Sync {
 
     /// 参加者の区分を取得する
     async fn find_target_status_by_id(&self, pid: &UserId) -> Result<ParticipantTargetStatus>;
-
-    /// 参加者のお気に入りを取得する
-    async fn find_favorite_by_id(&self, pid: &UserId) -> Result<Vec<Volunteer>>;
-
-    /// 参加者の活動履歴を取得する
-    async fn find_activity_by_id(&self, pid: &UserId) -> Result<Vec<Volunteer>>;
-
-    /// 参加者の予定を取得する
-    async fn find_scheduled_activity_by_id(&self, pid: &UserId) -> Result<Vec<Volunteer>>;
 
     /// 参加者が存在するか確認する
     async fn exists(&self, pid: &UserId) -> Result<bool>;

--- a/backend/tools/sql/init-insert.sql
+++ b/backend/tools/sql/init-insert.sql
@@ -112,6 +112,36 @@ INSERT INTO volunteer(
   NOW()
 );
 
+INSERT INTO volunteer(
+  vid,
+  gid,
+  title,
+  message,
+  overview,
+  recruited_num,
+  place,
+  start_at,
+  finish_at,
+  as_group,
+  deadline_on,
+  registered_at,
+  updated_at
+) VALUES (
+  "01HN22FWVK9949XC4KP8P517C3",
+  "group_account000000000000000",
+  "Scheduled volunteer",
+  "Scheduled message",
+  "Scheduled overview",
+  5,
+  "front of Tokyo Station",
+  "2024-4-1 11:00:00",
+  "2024-4-1 17:00:00",
+  false,
+  "2024-3-20",
+  NOW(),
+  NOW()
+);
+
 INSERT INTO volunteer_region VALUES (
   "01HKXVVVKBR6G8240N7HWSPR7M",
   1
@@ -196,6 +226,18 @@ INSERT INTO apply VALUES (
   "01HKXVVVKBR6G8240N7HWSPR7M",
   "participant_account000000001",
   "2024-1-13 12:00:00",
+  false,
+  0,
+  NULL,
+  false
+);
+
+
+INSERT INTO apply VALUES (
+  "01HN22NKTWY3SHA4SMC8GQX83T",
+  "01HN22FWVK9949XC4KP8P517C3",
+  "participant_account000000000",
+  "2024-1-23 12:00:00",
   false,
   0,
   NULL,


### PR DESCRIPTION
## 対応する課題のチケット URL

#80 

## :question: 目的・背景(Why)

以下の機能の作成
- uidから、お気に入りに登録していたボランティアの一括取得
- uidから、過去の活動履歴(ボランティア情報)を一括取得
- uidから、今後の活動予定(ボランティア情報)を一括取得

## :up: 変更点(What)

`query/`
- ├`repository/src/`
-   　　　　　 　├`user_account/participant.rs` (ディレクトリ変更による未実装メソッドの削除)
-   　　　　　 　└`activities/volunteer.rs`
- ├`infrastructure/src/`
-   　　　　　 　　　├`user_account/participant.rs` (ディレクトリ変更による未実装メソッドの削除)
-   　　　　　 　　　├`activities/volunteer.rs`
-   　　　　 　　　　└`resolvers.rs`

## :pick: やったこと(How)

以下の機能の実装
- getFavoriteByUid(uid): uidから、お気に入りに登録していたボランティアの一括取得
- getActivitiesByUid(uid): uidから、過去の活動履歴(ボランティア情報)を一括取得
- getScheduledActivitiesByUid(uid): uidから、今後の活動予定(ボランティア情報)を一括取得
- volunteerの取得時、削除済み(is_deleted=true)のデータを除外するように変更

## :red_circle: デプロイ・マイグレーション

- conflictこちらで解消します

## :camera_flash: （動作）確認内容・スクショ

![image](https://github.com/ishida-0622/VolunScout/assets/97711353/4533d2a2-9779-429a-8fb4-5e595b0a8e89)
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/7d56a753-5fbf-4707-af7a-3f78ecf1750a)

close #80 