### PR TITLE
refactor: separate methods between volunteer and elements

### DIFF
--- a/backend/query/infrastructure/src/resolvers.rs
+++ b/backend/query/infrastructure/src/resolvers.rs
@@ -19,7 +19,7 @@ use query_repository::{
         }, activities::{
             scout::{ScoutRepository, Scout},
             apply::{Apply, ApplyRepository},
-            volunteer::{VolunteerQueryRepository, VolunteerReadModel},
+            volunteer::{VolunteerElementsReadModel, VolunteerQueryRepository, VolunteerReadModel},
             review::{Review, ParticipantReviewRepository, VolunteerReviewRepository}
         }
 };
@@ -406,6 +406,25 @@ impl QueryRoot {
         Ok(scout)
     }
 
+    /// 指定されたvidのボランティア要素情報を取得する
+    ///
+    /// ## 引数
+    /// - `vid` - vid
+    ///
+    /// ## 返り値
+    /// - `VolunteerElementsReadModel` - ボランティア要素情報
+    async fn get_volunteer_elements_by_id<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        vid: String,
+    ) -> Result<VolunteerElementsReadModel> {
+        let ctx: &ServiceContext = ctx.data::<ServiceContext>().unwrap();
+        let vid = VolunteerId::from_str(&vid);
+        let volunteer: VolunteerElementsReadModel = ctx.volunteer_dao.find_elements_by_id(&vid).await?;
+
+        Ok(volunteer)
+    }
+
     /// 指定されたvidのボランティア情報を取得する
     ///
     /// ## 引数
@@ -500,7 +519,7 @@ impl QueryRoot {
 
         Ok(volunteers)
     }
-  
+
     /// 指定されたuidとvidの参加者レビュー情報を取得する
     ///
     /// ## 引数

--- a/backend/query/repository/src/activities/volunteer.rs
+++ b/backend/query/repository/src/activities/volunteer.rs
@@ -3,7 +3,7 @@ use async_graphql::SimpleObject;
 use async_trait::async_trait;
 use chrono::{NaiveDate, NaiveDateTime};
 
-use domain::model::{user_account::user_id::UserId, volunteer::VolunteerId};
+use domain::model::{user_account::user_id::UserId, volunteer::{Volunteer, VolunteerId}};
 /// ボランティアリードモデル
 #[derive(SimpleObject, sqlx::Type)]
 pub struct VolunteerReadModel {
@@ -80,8 +80,45 @@ impl VolunteerReadModel {
     }
 }
 
+/// ボランティア要素類リードモデル
+#[derive(SimpleObject, sqlx::Type)]
+pub struct VolunteerElementsReadModel {
+    pub vid: String,
+    pub regions: Vec<String>,
+    pub themes: Vec<String>,
+    pub required_themes: Vec<String>,
+    pub conditions: Vec<String>,
+    pub required_conditions: Vec<String>,
+    pub target_status: Vec<String>,
+}
+
+impl VolunteerElementsReadModel {
+    pub fn new(
+        vid: String,
+        regions: Vec<String>,
+        themes: Vec<String>,
+        required_themes: Vec<String>,
+        conditions: Vec<String>,
+        required_conditions: Vec<String>,
+        target_status: Vec<String>,
+    ) -> VolunteerElementsReadModel {
+        VolunteerElementsReadModel {
+            vid,
+            regions,
+            themes,
+            required_themes,
+            conditions,
+            required_conditions,
+            target_status,
+        }
+    }
+}
+
 #[async_trait]
 pub trait VolunteerQueryRepository: Send + Sync {
+    /// ボランティアに関連する要素をボランティアIDから取得する
+    async fn find_elements_by_id(&self, vid: &VolunteerId) -> Result<VolunteerElementsReadModel>;
+
     /// ボランティアをボランティアidで取得する
     async fn find_by_id(&self, vid: &VolunteerId) -> Result<VolunteerReadModel>;
 


### PR DESCRIPTION
## 対応する課題のチケット URL

#83 

## :question: 目的・背景(Why)

- ボランティアの取得系は並べ替えや条件絞り込みが多いため、様々な条件に対応できるよう、細かく取得を分割し、各メソッドで呼び出す方式に変更する

## :up: 変更点(What)

`backend/query/`
 　　　　　├`infrastructure/src/`
- 　　　│　　　　　　　　├`activities/volunteer.rs` find_elements_by_idの実装、find_by_idからの呼び出しに変更
- 　　　│　　　　　　　　└`resolvers.rs` ルーティングを設定
- 　　　└`repository/src/activities/volunteer.rs` VolunteerElementsReadModelsの実装

## :pick: やったこと(How)

- getVolunteerElementsById(vid) => ボランティア要素

## :camera_flash: （動作）確認内容・スクショ

![image](https://github.com/ishida-0622/VolunScout/assets/97711353/7161220d-f085-4add-bb06-1ec75ea95759)

close #83 
