### PR TITLE
fix: target statuses are able to be selected when a volunteer is registered

### DIFF
--- a/backend/command/infrastructure/src/controllers/participant.rs
+++ b/backend/command/infrastructure/src/controllers/participant.rs
@@ -227,7 +227,7 @@ pub async fn create_participant_account(
         required_theme,
         condition,
         required_condition,
-        target_status,
+        vec![target_status],
     );
 
     match repository
@@ -390,7 +390,7 @@ pub async fn update_participant_account(
         required_theme,
         condition,
         required_condition,
-        target_status,
+        vec![target_status],
     );
 
     match repository

--- a/backend/command/infrastructure/src/controllers/volunteer.rs
+++ b/backend/command/infrastructure/src/controllers/volunteer.rs
@@ -49,7 +49,7 @@ pub struct CreateVolunteerRequestBody {
     #[schema()]
     pub reward: Option<String>,
     #[schema(required = true)]
-    pub target_status: String,
+    pub target_status: Vec<String>,
     pub photos: Option<Vec<String>>,
 }
 
@@ -91,7 +91,7 @@ pub struct UpdateVolunteerRequestBody {
     #[schema()]
     pub reward: Option<String>,
     #[schema(required = true)]
-    pub target_status: String,
+    pub target_status: Vec<String>,
     pub photos: Option<Vec<String>>,
 }
 
@@ -187,19 +187,21 @@ pub async fn create_volunteer(
         .map(|t: &String| Condition::from_str(t).unwrap())
         .collect::<Vec<Condition>>();
     let reward: Option<String> = body.reward;
-    let target_status: TargetStatus = match TargetStatus::from_str(&body.target_status) {
-        Ok(target_status) => target_status,
-        Err(error) => {
-            log::warn!("error = {}", error);
-            return (
+    let target_status: Vec<TargetStatus> = body
+        .target_status
+        .iter()
+        .map(|t: &String| TargetStatus::from_str(t).unwrap())
+        .collect::<Vec<TargetStatus>>();
+
+    if target_status.len() == 0 {
+        return (
                 StatusCode::BAD_REQUEST,
                 Json(WriteApiResponseFailureBody {
-                    message: error.to_string(),
+                    message: "target status is null".to_string(),
                 }),
             )
                 .into_response();
-        }
-    };
+    }
 
     let terms: Terms = Terms::new(
         region,
@@ -207,7 +209,6 @@ pub async fn create_volunteer(
         required_theme,
         condition,
         required_condition,
-        // reward,
         target_status,
     );
 
@@ -309,19 +310,21 @@ pub async fn update_volunteer(
         .map(|t: &String| Condition::from_str(t).unwrap())
         .collect::<Vec<Condition>>();
     let reward: Option<String> = body.reward;
-    let target_status: TargetStatus = match TargetStatus::from_str(&body.target_status) {
-        Ok(target_status) => target_status,
-        Err(error) => {
-            log::warn!("error = {}", error);
-            return (
+    let target_status: Vec<TargetStatus> = body
+        .target_status
+        .iter()
+        .map(|t: &String| TargetStatus::from_str(t).unwrap())
+        .collect::<Vec<TargetStatus>>();
+
+    if target_status.len() == 0 {
+        return (
                 StatusCode::BAD_REQUEST,
                 Json(WriteApiResponseFailureBody {
-                    message: error.to_string(),
+                    message: "target status is null".to_string(),
                 }),
             )
                 .into_response();
-        }
-    };
+    }
 
     let terms: Terms = Terms::new(
         region,

--- a/backend/command/infrastructure/src/user_account/participant.rs
+++ b/backend/command/infrastructure/src/user_account/participant.rs
@@ -55,7 +55,7 @@ impl ParticipantUserRepository for ParticipantAccountImpl {
         sqlx::query!(
             "INSERT INTO participant_element (uid, eid) VALUES (?, ?)",
             id,
-            terms.target_status.to_id()
+            terms.target_status[0].to_id()
         )
         .execute(&self.pool)
         .await?;
@@ -182,7 +182,7 @@ impl ParticipantUserRepository for ParticipantAccountImpl {
         sqlx::query!(
             "INSERT INTO participant_element (uid, eid) VALUES (?, ?)",
             id,
-            terms.target_status.to_id()
+            terms.target_status[0].to_id()
         )
         .execute(&self.pool)
         .await?;

--- a/backend/domain/src/model/terms.rs
+++ b/backend/domain/src/model/terms.rs
@@ -11,7 +11,7 @@ pub struct Terms {
     pub required_themes: Vec<Theme>,
     pub conditions: Vec<Condition>,
     pub required_conditions: Vec<Condition>,
-    pub target_status: TargetStatus,
+    pub target_status: Vec<TargetStatus>,
 }
 
 impl Terms {
@@ -21,7 +21,7 @@ impl Terms {
         required_themes: Vec<Theme>,
         conditions: Vec<Condition>,
         required_conditions: Vec<Condition>,
-        target_status: TargetStatus,
+        target_status: Vec<TargetStatus>,
     ) -> Terms {
         Terms {
             regions,


### PR DESCRIPTION
## 対応する課題のチケット URL

#85 

## :question: 目的・背景(Why)

- ボランティア作成時、募集対象が複数指定できない問題を修正

## :up: 変更点(What)

- ボランティア登録時・変更時、target_status(対象)を複数指定できるように変更
- 尚、空配列(target_status:[])は許可せず、何か一つは指定するものとする
- 参加者側のRequestBodyは変更なし(変わらず文字列)

## :pick: やったこと(How)

`backend/`
　　　├`command/infrastructure/src/`
-  　│　　　　　　　　　　 　├`activities/volunteer.rs` SQLを、複数のtarget_statusをvolunteer_elementテーブルに追加するよう変更
-  　│　　　　　　　　　　 　├`user_account/participant.rs` terms.target_statusがVectorに変わったことに伴う修正
  　│　　　　　　　　　　 　└`controllers/`
-  　│　　　　　　　　　　 　　　　　├`volunteer.rs` リクエストのtarget_statusをベクタ型で受け取るように変更
-  　│　　　　　　　　　　　　　　 　└`participant.rs` terms.target_statusがVectorに変わったことに伴う修正
- 　└`domain/src/model/terms.rs` target_statusの型をTargetStatusからVec\<TargetStatus\>に変更

## :camera_flash: （動作）確認内容・スクショ

ボランティア登録時、target_statusを複数指定できるように変更
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/5e01de81-e809-4569-8121-25babe563600)

空配列の場合はエラーを返す
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/1e3bccc9-f2dd-49b2-b82d-3d0b94d1e5a5)

ボランティア更新時、target_statusを複数指定できるように変更
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/2a65be17-0ef9-4cbf-8da4-93b2938d032c)

空配列の場合はエラーを返す
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/bd139dc4-20f4-4382-bd39-e06d2144479a)

参加者のRequestBodyに変更なし
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/69af33c6-280b-4894-b939-a63c568251bf)
![image](https://github.com/ishida-0622/VolunScout/assets/97711353/0e148106-143c-4e6b-a2ca-2d9c49788a60)

close #85 
